### PR TITLE
Traduire les fichiers ts / js / svg

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -176,12 +176,12 @@ export default defineConfig({
 
     nav: [
       { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
-      { text: 'Config', link: '/config/', activeMatch: '/config/' },
+      { text: 'Configuration', link: '/config/', activeMatch: '/config/' },
       { text: 'Plugins', link: '/plugins/', activeMatch: '/plugins/' },
       {
         text: 'Ressources',
         items: [
-          { text: 'L'équipe', link: '/team' },
+          { text: 'L\'équipe', link: '/team' },
           { text: 'Blog', link: '/blog' },
           { text: 'Releases', link: '/releases' },
           {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -283,7 +283,7 @@ export default defineConfig({
               link: '/guide/static-deploy',
             },
             {
-              text: 'Variables d'environnement et Modes',
+              text: 'Variables d\'environnement et Modes',
               link: '/guide/env-and-mode',
             },
             {
@@ -388,7 +388,7 @@ export default defineConfig({
               link: '/config/preview-options',
             },
             {
-              text: 'Options d‘optimisation des dépendances',
+              text: 'Options d\'optimisation des dépendances',
               link: '/config/dep-optimization-options',
             },
             {
@@ -427,7 +427,7 @@ export default defineConfig({
               link: '/changes/per-environment-apis',
             },
             {
-              text: 'Rendu côté serveur (SSR) avec l‘API ModuleRunner',
+              text: 'Rendu côté serveur (SSR) avec l\'API ModuleRunner',
               link: '/changes/ssr-using-modulerunner',
             },
             {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,7 +9,7 @@ import llmstxt from 'vitepress-plugin-llms'
 import type { PluginOption } from 'vite'
 import { buildEnd } from './buildEnd.config'
 
-const ogDescription = 'Next Generation Frontend Tooling'
+const ogDescription = 'Le tooling front-end nouvelle génération'
 const ogImage = 'https://vite.dev/og-image.jpg'
 const ogTitle = 'Vite'
 const ogUrl = 'https://vite.dev'
@@ -41,19 +41,19 @@ const additionalTitle = ((): string => {
 const versionLinks = ((): DefaultTheme.NavItemWithLink[] => {
   const oldVersions: DefaultTheme.NavItemWithLink[] = [
     {
-      text: 'Vite 5 Docs',
+      text: 'Docs Vite 5',
       link: 'https://v5.vite.dev',
     },
     {
-      text: 'Vite 4 Docs',
+      text: 'Docs Vite 4',
       link: 'https://v4.vite.dev',
     },
     {
-      text: 'Vite 3 Docs',
+      text: 'Docs Vite 3',
       link: 'https://v3.vite.dev',
     },
     {
-      text: 'Vite 2 Docs',
+      text: 'Docs Vite 2',
       link: 'https://v2.vite.dev',
     },
   ]
@@ -63,7 +63,7 @@ const versionLinks = ((): DefaultTheme.NavItemWithLink[] => {
     case 'local':
       return [
         {
-          text: 'Vite 6 Docs (release)',
+          text: 'Docs Vite 6(release)',
           link: 'https://vite.dev',
         },
         ...oldVersions,
@@ -75,7 +75,7 @@ const versionLinks = ((): DefaultTheme.NavItemWithLink[] => {
 
 export default defineConfig({
   title: `Vite${additionalTitle}`,
-  description: 'Next Generation Frontend Tooling',
+  description: 'Le tooling front-end nouvelle génération',
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
@@ -136,6 +136,7 @@ export default defineConfig({
     pt: { label: 'Português', link: 'https://pt.vite.dev' },
     ko: { label: '한국어', link: 'https://ko.vite.dev' },
     de: { label: 'Deutsch', link: 'https://de.vite.dev' },
+    fr: { label: 'Français', link: 'https://fr.vite.dev' },
   },
 
   themeConfig: {
@@ -143,7 +144,7 @@ export default defineConfig({
 
     editLink: {
       pattern: 'https://github.com/vitejs/vite/edit/main/docs/:path',
-      text: 'Suggest changes to this page',
+      text: 'Suggérer des changements sur cette page',
     },
 
     socialLinks: [
@@ -159,7 +160,7 @@ export default defineConfig({
       apiKey: '208bb9c14574939326032b937431014b',
       indexName: 'vitejs',
       searchParameters: {
-        facetFilters: ['tags:en'],
+        facetFilters: ['tags:fr'],
       },
     },
 
@@ -169,7 +170,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: `Released under the MIT License. (${commitRef})`,
+      message: `Publié sous licence MIT. (${commitRef})`,
       copyright: 'Copyright © 2019-present VoidZero Inc. & Vite Contributors',
     },
 
@@ -178,9 +179,9 @@ export default defineConfig({
       { text: 'Config', link: '/config/', activeMatch: '/config/' },
       { text: 'Plugins', link: '/plugins/', activeMatch: '/plugins/' },
       {
-        text: 'Resources',
+        text: 'Ressources',
         items: [
-          { text: 'Team', link: '/team' },
+          { text: 'L'équipe', link: '/team' },
           { text: 'Blog', link: '/blog' },
           { text: 'Releases', link: '/releases' },
           {
@@ -210,15 +211,15 @@ export default defineConfig({
                 link: 'https://viteconf.org',
               },
               {
-                text: 'DEV Community',
+                text: 'Communauté DEV',
                 link: 'https://dev.to/t/vite',
               },
               {
-                text: 'Changelog',
+                text: 'Historique des modifications',
                 link: 'https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md',
               },
               {
-                text: 'Contributing',
+                text: 'Contribuer',
                 link: 'https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md',
               },
             ],
@@ -237,15 +238,15 @@ export default defineConfig({
           text: 'Introduction',
           items: [
             {
-              text: 'Getting Started',
+              text: 'Guide',
               link: '/guide/',
             },
             {
-              text: 'Philosophy',
+              text: 'Philosophie',
               link: '/guide/philosophy',
             },
             {
-              text: 'Why Vite',
+              text: 'Pourquoi utiliser Vite',
               link: '/guide/why',
             },
           ],
@@ -262,39 +263,39 @@ export default defineConfig({
               link: '/guide/cli',
             },
             {
-              text: 'Using Plugins',
+              text: 'Plugins',
               link: '/guide/using-plugins',
             },
             {
-              text: 'Dependency Pre-Bundling',
+              text: 'Pré-construire des dépendances',
               link: '/guide/dep-pre-bundling',
             },
             {
-              text: 'Static Asset Handling',
+              text: 'Gestion des ressources statiques',
               link: '/guide/assets',
             },
             {
-              text: 'Building for Production',
+              text: 'Construire pour la Production',
               link: '/guide/build',
             },
             {
-              text: 'Deploying a Static Site',
+              text: 'Déployer un site statique',
               link: '/guide/static-deploy',
             },
             {
-              text: 'Env Variables and Modes',
+              text: 'Variables d'environnement et Modes',
               link: '/guide/env-and-mode',
             },
             {
-              text: 'Server-Side Rendering (SSR)',
+              text: 'Rendu côté serveur (SSR)',
               link: '/guide/ssr',
             },
             {
-              text: 'Backend Integration',
+              text: 'Integration avec le Backend',
               link: '/guide/backend-integration',
             },
             {
-              text: 'Troubleshooting',
+              text: 'Dépannage',
               link: '/guide/troubleshooting',
             },
             {
@@ -306,11 +307,11 @@ export default defineConfig({
               link: '/guide/rolldown',
             },
             {
-              text: 'Migration from v5',
+              text: 'Migration depuis la v5',
               link: '/guide/migration',
             },
             {
-              text: 'Breaking Changes',
+              text: 'Changements majeurs',
               link: '/changes/',
             },
           ],
@@ -319,32 +320,32 @@ export default defineConfig({
           text: 'APIs',
           items: [
             {
-              text: 'Plugin API',
+              text: 'API des plugin',
               link: '/guide/api-plugin',
             },
             {
-              text: 'HMR API',
+              text: 'API du HMR',
               link: '/guide/api-hmr',
             },
             {
-              text: 'JavaScript API',
+              text: 'JavaScript',
               link: '/guide/api-javascript',
             },
             {
-              text: 'Config Reference',
+              text: 'Configuration',
               link: '/config/',
             },
           ],
         },
         {
-          text: 'Environment API',
+          text: 'API des environnements',
           items: [
             {
               text: 'Introduction',
               link: '/guide/api-environment',
             },
             {
-              text: 'Environment Instances',
+              text: 'Instances des environnements',
               link: '/guide/api-environment-instances',
             },
             {
@@ -364,38 +365,38 @@ export default defineConfig({
       ],
       '/config/': [
         {
-          text: 'Config',
+          text: 'Configuration',
           items: [
             {
-              text: 'Configuring Vite',
+              text: 'Configurer Vite',
               link: '/config/',
             },
             {
-              text: 'Shared Options',
+              text: 'Options partagées',
               link: '/config/shared-options',
             },
             {
-              text: 'Server Options',
+              text: 'Options serveur',
               link: '/config/server-options',
             },
             {
-              text: 'Build Options',
+              text: 'Options de construction',
               link: '/config/build-options',
             },
             {
-              text: 'Preview Options',
+              text: 'Options de prévisualisation',
               link: '/config/preview-options',
             },
             {
-              text: 'Dep Optimization Options',
+              text: 'Options d‘optimisation des dépendances',
               link: '/config/dep-optimization-options',
             },
             {
-              text: 'SSR Options',
+              text: 'Options du rendu côté serveur (SSR)',
               link: '/config/ssr-options',
             },
             {
-              text: 'Worker Options',
+              text: 'Options du worker',
               link: '/config/worker-options',
             },
           ],
@@ -403,18 +404,18 @@ export default defineConfig({
       ],
       '/changes/': [
         {
-          text: 'Breaking Changes',
+          text: 'Changements majeurs',
           link: '/changes/',
         },
         {
-          text: 'Current',
+          text: 'Actuel',
           items: [],
         },
         {
-          text: 'Future',
+          text: 'Futur',
           items: [
             {
-              text: 'this.environment in Hooks',
+              text: 'this.environment dans les Hooks',
               link: '/changes/this-environment-in-hooks',
             },
             {
@@ -422,21 +423,21 @@ export default defineConfig({
               link: '/changes/hotupdate-hook',
             },
             {
-              text: 'Move to per-environment APIs',
+              text: 'Passer au per-environnements APIS',
               link: '/changes/per-environment-apis',
             },
             {
-              text: 'SSR using ModuleRunner API',
+              text: 'Rendu côté serveur (SSR) avec l‘API ModuleRunner',
               link: '/changes/ssr-using-modulerunner',
             },
             {
-              text: 'Shared plugins during build',
+              text: 'Partager des plugins durant la construction',
               link: '/changes/shared-plugins-during-build',
             },
           ],
         },
         {
-          text: 'Past',
+          text: 'Passé',
           items: [],
         },
       ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -255,7 +255,7 @@ export default defineConfig({
           text: 'Guide',
           items: [
             {
-              text: 'Features',
+              text: 'Fonctionnalités',
               link: '/guide/features',
             },
             {
@@ -267,7 +267,7 @@ export default defineConfig({
               link: '/guide/using-plugins',
             },
             {
-              text: 'Pré-construire des dépendances',
+              text: 'Pré-build des dépendances',
               link: '/guide/dep-pre-bundling',
             },
             {
@@ -275,7 +275,7 @@ export default defineConfig({
               link: '/guide/assets',
             },
             {
-              text: 'Construire pour la Production',
+              text: 'Build pour la production',
               link: '/guide/build',
             },
             {
@@ -328,7 +328,7 @@ export default defineConfig({
               link: '/guide/api-hmr',
             },
             {
-              text: 'JavaScript',
+              text: 'API JavaScript',
               link: '/guide/api-javascript',
             },
             {

--- a/docs/.vitepress/theme/composables/sponsor.ts
+++ b/docs/.vitepress/theme/composables/sponsor.ts
@@ -99,17 +99,17 @@ export function useSponsor() {
 function mapSponsors(sponsors: Sponsors) {
   return [
     {
-      tier: 'in partnership with',
+      tier: 'en partenariat avec',
       size: 'big',
       items: viteSponsors['special'],
     },
     {
-      tier: 'Platinum Sponsors',
+      tier: 'Sponsors Platinum',
       size: 'big',
       items: mapImgPath(sponsors['platinum']),
     },
     {
-      tier: 'Gold Sponsors',
+      tier: 'Sponsors Gold',
       size: 'medium',
       items: [...mapImgPath(sponsors['gold']), ...viteSponsors['gold']],
     },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -2,10 +2,10 @@ export const core = [
   {
     avatar: 'https://www.github.com/yyx990803.png',
     name: 'Evan You',
-    title: 'Creator',
+    title: 'Créateur',
     org: 'Vue.js',
     orgLink: 'https://vuejs.org/',
-    desc: 'Independent open source developer, creator of Vue.js and Vite.',
+    desc: 'Développeur open source indépendant, créateur de Vue.js et de Vite.',
     links: [
       { icon: 'github', link: 'https://github.com/yyx990803' },
       { icon: 'x', link: 'https://x.com/youyuxi' },
@@ -16,10 +16,10 @@ export const core = [
   {
     avatar: 'https://www.github.com/patak-dev.png',
     name: 'Patak',
-    title: 'A collaborative being',
+    title: 'Un être collaboratif',
     org: 'StackBlitz',
     orgLink: 'https://stackblitz.com/',
-    desc: 'Core team member of Vite. Team member of Vue.',
+    desc: 'Membre de l\'équipe principale Vite. Membre de l\'équipe Vue.',
     links: [
       { icon: 'github', link: 'https://github.com/patak-dev' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/patak.dev' },
@@ -30,10 +30,10 @@ export const core = [
   {
     avatar: 'https://www.github.com/antfu.png',
     name: 'Anthony Fu',
-    title: 'A fanatical open sourceror',
+    title: 'Open sourcier fanatique',
     org: 'NuxtLabs',
     orgLink: 'https://nuxtlabs.com/',
-    desc: 'Core team member of Vite & Vue. Working at NuxtLabs.',
+    desc: 'Membre des équipes principales Vite & Vue. Travaille pour NuxtLabs.',
     links: [
       { icon: 'github', link: 'https://github.com/antfu' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/antfu.me' },
@@ -44,8 +44,8 @@ export const core = [
   {
     avatar: 'https://github.com/bluwy.png',
     name: 'Bjorn Lu',
-    title: 'Open Source Developer',
-    desc: 'Building tools for fun.',
+    title: 'Développeur Open Source',
+    desc: 'Fait des outils pour le plaisir.',
     links: [
       { icon: 'github', link: 'https://github.com/bluwy' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },
@@ -57,8 +57,8 @@ export const core = [
   {
     avatar: 'https://github.com/sapphi-red.png',
     name: 'green',
-    title: 'Web Developer',
-    desc: 'Vite core team member. Call me sapphi or green or midori ;)',
+    title: 'Développeur',
+    desc: 'Membre de l\'équipe principale Vite. Appellez moi sapphi ou green ou midori ;)',
     links: [
       { icon: 'github', link: 'https://github.com/sapphi-red' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/sapphi.red' },
@@ -70,8 +70,8 @@ export const core = [
   {
     avatar: 'https://github.com/ArnaudBarre.png',
     name: 'Arnaud Barré',
-    title: 'Frontend Developer',
-    desc: 'Passionate by tooling around TypeScript and React.',
+    title: 'Développeur Frontend',
+    desc: 'Passionné par les outils en rapport avec TypeScript et React.',
     links: [
       { icon: 'github', link: 'https://github.com/ArnaudBarre' },
       {
@@ -85,8 +85,8 @@ export const core = [
   {
     avatar: 'https://github.com/dominikg.png',
     name: 'Dominik G.',
-    title: 'Resident CI Expert',
-    desc: 'Team Member of Vite and Svelte',
+    title: 'Spécialiste de la CI',
+    desc: 'Membre des équipes Vite et Svelte',
     links: [
       { icon: 'github', link: 'https://github.com/dominikg' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@dominikg' },
@@ -96,8 +96,8 @@ export const core = [
   {
     avatar: 'https://github.com/sheremet-va.png',
     name: 'Vladimir',
-    title: 'Core team member of Vitest & Vite',
-    desc: 'An open source fullstack developer',
+    title: 'Membre des équipes principales Vitest & Vite',
+    desc: 'Développeur fullstack open source',
     links: [
       { icon: 'github', link: 'https://github.com/sheremet-va' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/erus.dev' },
@@ -108,8 +108,8 @@ export const core = [
   {
     avatar: 'https://github.com/hi-ogawa.png',
     name: 'Hiroshi Ogawa',
-    title: 'Team Member of Vitest & Vite',
-    desc: 'Open source enthusiast',
+    title: 'Membre des équipes Vitest & Vite',
+    desc: 'Enthousiaste de l\'open source',
     links: [
       { icon: 'github', link: 'https://github.com/hi-ogawa' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/hiogawa.bsky.social' },
@@ -119,7 +119,7 @@ export const core = [
   {
     avatar: 'https://github.com/btea.png',
     name: 'btea',
-    title: 'Web Developer',
+    title: 'Développeur web',
     links: [{ icon: 'github', link: 'https://github.com/btea' }],
   },
 ]
@@ -129,7 +129,7 @@ export const emeriti = [
     avatar: 'https://i.imgur.com/KMed6rQ.jpeg',
     name: 'Alec Larson',
     title: 'Entrepreneur',
-    desc: 'Dabbling in social ecommerce, meta frameworks, and board games',
+    desc: 'Adore le commerce social, les méta-frameworks et les jeux de plateaux',
     links: [
       { icon: 'github', link: 'https://github.com/aleclarson' },
       { icon: 'x', link: 'https://x.com/retropragma' },
@@ -142,8 +142,8 @@ export const emeriti = [
   {
     avatar: 'https://github.com/poyoho.png',
     name: 'yoho',
-    title: 'Frontend Developer',
-    desc: 'Frontend. Vite team member.',
+    title: 'Développeur frontend',
+    desc: 'Frontend. Membre de l\'équipe Vite.',
     links: [
       { icon: 'github', link: 'https://github.com/poyoho' },
       { icon: 'x', link: 'https://x.com/yoho_po' },
@@ -152,8 +152,8 @@ export const emeriti = [
   {
     avatar: 'https://github.com/ygj6.png',
     name: 'ygj6',
-    title: 'Developer',
-    desc: 'Web Developer. Vue & Vite team member',
+    title: 'Développeur',
+    desc: 'Développeur Web. Membre des équipes Vue & Vite',
     links: [
       { icon: 'github', link: 'https://github.com/ygj6' },
       { icon: 'x', link: 'https://x.com/ygj_66' },
@@ -162,9 +162,9 @@ export const emeriti = [
   {
     avatar: 'https://github.com/Niputi.png',
     name: 'Niputi',
-    title: 'Developer',
-    org: 'Computershare Denmark',
-    desc: 'weeb/javascript lover.',
+    title: 'Développeur',
+    org: 'Computershare Danemark',
+    desc: 'weeb / passionné de JavaScript.',
     links: [
       { icon: 'github', link: 'https://github.com/Niputi' },
       { icon: 'x', link: 'https://x.com/Niputi_' },
@@ -174,13 +174,13 @@ export const emeriti = [
   {
     avatar: 'https://github.com/underfin.png',
     name: 'underfin',
-    title: 'Developer',
+    title: 'Développeur',
     links: [{ icon: 'github', link: 'https://github.com/underfin' }],
   },
   {
     avatar: 'https://github.com/GrygrFlzr.png',
     name: 'GrygrFlzr',
-    title: 'Developer',
+    title: 'Développeur',
     links: [
       { icon: 'github', link: 'https://github.com/GrygrFlzr' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/bsky.cybeast.dev' },
@@ -189,16 +189,16 @@ export const emeriti = [
   {
     avatar: 'https://github.com/nihalgonsalves.png',
     name: 'Nihal Gonsalves',
-    title: 'Senior Software Engineer',
+    title: 'Ingénieur logiciel senior',
     links: [{ icon: 'github', link: 'https://github.com/nihalgonsalves' }],
   },
   {
     avatar: 'https://github.com/Shinigami92.png',
     name: 'Shinigami',
-    title: 'Senior Frontend Engineer',
+    title: 'Ingénieur frontend senior',
     org: 'Faker',
     orgLink: 'https://fakerjs.dev',
-    desc: 'Passionate TypeScript enthusiast working extensively with Vue SPA.',
+    desc: 'Passionné par TypeScript, travaille intensivement avec des SPA Vue.',
     links: [
       { icon: 'github', link: 'https://github.com/Shinigami92' },
       { icon: 'mastodon', link: 'https://elk.zone/mas.to/@Shini92' },
@@ -207,10 +207,10 @@ export const emeriti = [
   {
     avatar: 'https://github.com/haoqunjiang.png',
     name: 'Haoqun Jiang',
-    title: 'Core Team Member',
+    title: 'Membre de l\'équipe principale',
     org: 'Vue.js',
     orgLink: 'https://vuejs.org/',
-    desc: 'Curator of best practices for Vue.js tooling',
+    desc: 'Garant des bonnes pratiques pour les outils Vue.js',
     links: [
       { icon: 'github', link: 'https://github.com/haoqunjiang' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/haoqun.dev' },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -19,7 +19,7 @@ export const core = [
     title: 'Un être collaboratif',
     org: 'StackBlitz',
     orgLink: 'https://stackblitz.com/',
-    desc: 'Membre de l\'équipe principale Vite. Membre de l\'équipe Vue.',
+    desc: 'Membre de la Core Team Vite. Membre de l\'équipe Vue.',
     links: [
       { icon: 'github', link: 'https://github.com/patak-dev' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/patak.dev' },
@@ -58,7 +58,7 @@ export const core = [
     avatar: 'https://github.com/sapphi-red.png',
     name: 'green',
     title: 'Développeur',
-    desc: 'Membre de l\'équipe principale Vite. Appellez moi sapphi ou green ou midori ;)',
+    desc: 'Membre de la Core Team Vite. Appellez moi sapphi ou green ou midori ;)',
     links: [
       { icon: 'github', link: 'https://github.com/sapphi-red' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/sapphi.red' },
@@ -207,7 +207,7 @@ export const emeriti = [
   {
     avatar: 'https://github.com/haoqunjiang.png',
     name: 'Haoqun Jiang',
-    title: 'Membre de l\'équipe principale',
+    title: 'Membre de la Core Team',
     org: 'Vue.js',
     orgLink: 'https://vuejs.org/',
     desc: 'Garant des bonnes pratiques pour les outils Vue.js',


### PR DESCRIPTION
En se basant sur la documentation d'origine : 
https://github.com/tony19/vite-docs-template/blob/main/.github/CONTRIBUTING.md

Il est nécessaire de traduire les fichiers suivant : 

- [/docs/.vitepress/config.ts](https://github.com/sbenard/vite-french-translation/blob/main/docs/.vitepress/config.ts) (les `og*`, `footer.*`, `text` et les champs `link`)
- [/docs/.vitepress/theme/composables/sponsor.ts](https://github.com/sbenard/vite-french-translation/blob/acea14e/docs/.vitepress/theme/composables/sponsor.ts#L44) (les champs `tier`)
- [/docs/_data/team.js](https://github.com/sbenard/vite-french-translation/blob/main/docs/_data/team.js) (les `title` et champs `desc`)
